### PR TITLE
Support proxy passthrough of command origins and signatures

### DIFF
--- a/src/main/scala/com/sbuslab/sbus/Context.scala
+++ b/src/main/scala/com/sbuslab/sbus/Context.scala
@@ -20,6 +20,8 @@ case class Context(data: Map[String, String] = Map.empty) {
   def timestamp: Option[Long] = get(Headers.Timestamp).map(_.toLong)
   def ip: String              = get(Headers.Ip).orNull
   def userAgent: String       = get(Headers.UserAgent).orNull
+  def signature: String       = get(Headers.Signature).orNull
+  def origin: String          = get(Headers.Origin).orNull
 
   def withValue(key: String, value: Any): Context =
     withValue(key, if (value != null) value.toString else null)
@@ -39,6 +41,9 @@ case class Context(data: Map[String, String] = Map.empty) {
   def withTimeout(millis: Long): Context                = withValue(Headers.Timeout, millis.toString)
   def withRetries(max: Int): Context                    = withValue(Headers.RetryAttemptsMax, max.toString)
   def withRoutingKey(key: String): Context              = withValue(Headers.RoutingKey, key)
+  def withSignature(signature: String): Context         = withValue(Headers.Signature, signature)
+  def withOrigin(origin: String): Context               = withValue(Headers.Origin, origin)
+  def withProxyPass: Context                            = withValue(Headers.ProxyPass, true)
 
   def customData = data -- Context.notLoggedHeaders
 }
@@ -61,6 +66,8 @@ object Context {
     Headers.UserAgent,
     Headers.Origin,
     Headers.Signature,
+    Headers.MessageOrigin,
+    Headers.MessageSignature,
   )
 
   private val notLoggedHeaders =

--- a/src/main/scala/com/sbuslab/sbus/Headers.scala
+++ b/src/main/scala/com/sbuslab/sbus/Headers.scala
@@ -16,4 +16,7 @@ object Headers {
   val Signature        = "signature"
   val UserId           = "userId"
   val Auth             = "auth"
+  val MessageOrigin    = "message-origin"
+  val MessageSignature = "message-signature"
+  val ProxyPass        = "proxy-pass"
 }

--- a/src/main/scala/com/sbuslab/sbus/Sbus.scala
+++ b/src/main/scala/com/sbuslab/sbus/Sbus.scala
@@ -3,8 +3,11 @@ package com.sbuslab.sbus
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
+import com.sbuslab.sbus.auth.AuthProvider
 
-class Sbus(transport: Transport)(implicit ec: ExecutionContext) {
+class Sbus(transport: Transport, authProvider: AuthProvider)(implicit ec: ExecutionContext) {
+  def sign(routingKey: String, message: Any = null): Context =
+    authProvider.signCommand(Context.empty.withRoutingKey(routingKey), Option(message));
 
   def request[T](routingKey: String, msg: Any = null)(implicit context: Context = Context.empty, tag: ClassTag[T]): Future[T] =
     transport.send(routingKey, msg, context, tag.runtimeClass).mapTo[T]

--- a/src/main/scala/com/sbuslab/sbus/auth/AuthProvider.scala
+++ b/src/main/scala/com/sbuslab/sbus/auth/AuthProvider.scala
@@ -19,9 +19,13 @@ import com.sbuslab.sbus.{Context, Headers}
 
 trait AuthProvider {
   def signMessageRequest(context: Context, body: Array[Byte]): Context
+
   def verifyMessageSignature(context: Context, body: Array[Byte]): Try[Unit]
+
   def signCommand(context: Context, cmd: Option[Any]): Context
+
   def verifyCommandSignature(context: Context, body: Option[Array[Byte]]): Try[Unit]
+
   def authorizeCommand(context: Context): Try[Unit]
 }
 
@@ -219,9 +223,13 @@ class AuthProviderImpl(val conf: Config, val mapper: ObjectMapper, val dynamicPr
 class NoopAuthProvider extends AuthProvider {
   private val success = Success {}
 
-  override def signMessageRequest(context: Context, body: Array[Byte]): Context              = context
-  override def verifyMessageSignature(context: Context, body: Array[Byte]): Try[Unit]        = success
-  override def authorizeCommand(context: Context): Try[Unit]                                 = success
-  override def signCommand(context: Context, cmd: Option[Any]): Context                      = context
+  override def signMessageRequest(context: Context, body: Array[Byte]): Context = context
+
+  override def verifyMessageSignature(context: Context, body: Array[Byte]): Try[Unit] = success
+
+  override def authorizeCommand(context: Context): Try[Unit] = success
+
+  override def signCommand(context: Context, cmd: Option[Any]): Context = context
+
   override def verifyCommandSignature(context: Context, cmd: Option[Array[Byte]]): Try[Unit] = success
 }

--- a/src/main/scala/com/sbuslab/sbus/auth/AuthProvider.scala
+++ b/src/main/scala/com/sbuslab/sbus/auth/AuthProvider.scala
@@ -18,9 +18,11 @@ import com.sbuslab.model.{ForbiddenError, InternalServerError}
 import com.sbuslab.sbus.{Context, Headers}
 
 trait AuthProvider {
-  def sign(context: Context, body: Array[Byte]): Context
-  def verify(context: Context, body: Array[Byte]): Try[Unit]
-  def authorize(context: Context): Try[Unit]
+  def signMessageRequest(context: Context, body: Array[Byte]): Context
+  def verifyMessageSignature(context: Context, body: Array[Byte]): Try[Unit]
+  def signCommand(context: Context, cmd: Option[Any]): Context
+  def verifyCommandSignature(context: Context, body: Option[Array[Byte]]): Try[Unit]
+  def authorizeCommand(context: Context): Try[Unit]
 }
 
 class AuthProviderImpl(val conf: Config, val mapper: ObjectMapper, val dynamicProvider: DynamicAuthConfigProvider)
@@ -56,84 +58,140 @@ class AuthProviderImpl(val conf: Config, val mapper: ObjectMapper, val dynamicPr
 
   private val success = Success {}
 
-  override def sign(context: Context, body: Array[Byte]): Context = {
-    val signer = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm))
-    signer.initSign(privKey)
+  override def signMessageRequest(context: Context, body: Array[Byte]): Context = {
+    val edDSAEngine = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm))
+    edDSAEngine.initSign(privKey)
 
-    signer.update(body)
-    context.get(Headers.Timestamp) foreach { timestamp ⇒ signer.update(timestamp.getBytes) }
+    edDSAEngine.update(body)
 
-    val signature = Base64.getUrlEncoder.encodeToString(signer.sign())
+    addMessageHeadersToEngine(context, edDSAEngine)
 
-    log.debug(s"Signing sbus message request: : ${context.routingKey}, caller $serviceName, ip ${context.ip}, message ${context.messageId}, signature: $signature, timestamp ${context.get(
-      Headers.Timestamp
-    )}, body ${new String(body)}")
+    val signature = Base64.getUrlEncoder.encodeToString(edDSAEngine.sign())
+
+    log.debug(s"Signing sbus message: ${context.routingKey}, origin: $serviceName")
 
     context
-      .withValue(Headers.Origin, serviceName)
-      .withValue(Headers.Signature, signature)
+      .withValue(Headers.MessageOrigin, serviceName)
+      .withValue(Headers.MessageSignature, signature)
   }
 
-  override def verify(context: Context, body: Array[Byte]): Try[Unit] =
+  override def verifyMessageSignature(context: Context, body: Array[Byte]): Try[Unit] =
     (for {
-      caller    ← context.get(Headers.Origin)
-      signature ← context.get(Headers.Signature)
-      pubKey    ← getPublicKeys.get(caller)
+      origin    ← context.get(Headers.MessageOrigin)
+      signature ← context.get(Headers.MessageSignature)
+      pubKey    ← getPublicKeys.get(origin)
     } yield {
-      val vrf = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm))
-      vrf.initVerify(pubKey)
-      vrf.update(body)
-      context.get(Headers.Timestamp) foreach { timestamp ⇒ vrf.update(timestamp.getBytes) }
+      val edDSAEngine = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm))
+      edDSAEngine.initVerify(pubKey)
 
-      if (!vrf.verify(Base64.getUrlDecoder.decode(signature.replace('+', '-').replace('/', '_')))) {
+      edDSAEngine.update(body)
+
+      addMessageHeadersToEngine(context, edDSAEngine)
+
+      if (!edDSAEngine.verify(Base64.getUrlDecoder.decode(signature.replace('+', '-').replace('/', '_')))) {
         return failure(
-          s"Signature invalid for sbus request: ${context.routingKey}, caller $caller, ip ${context.ip}, message ${context.messageId}, signature: $signature, timestamp ${context.get(
-            Headers.Timestamp
-          )}, publicKey: ${Utils.bytesToHex(pubKey.getAbyte)}, body ${new String(body)}"
+          s"Signature invalid for sbus message: ${context.routingKey}, $origin"
         )
       }
 
       success
     }) getOrElse {
       failure(
-        s"Unauthenticated sbus request: ${context.routingKey}, caller ${context.get(Headers.Origin)}, ip ${context.ip}, messageId ${context.messageId}"
+        s"Unauthenticated sbus message: ${context.routingKey}, origin: ${context.get(Headers.MessageOrigin)}"
       )
     }
 
-  override def authorize(context: Context): Try[Unit] =
+  override def authorizeCommand(context: Context) = {
     (for {
-      caller     ← context.get(Headers.Origin)
+      origin     ← context.get(Headers.Origin)
       routingKey ← context.get(Headers.RoutingKey)
     } yield {
-      if (caller == serviceName) {
-        return success
+      if (origin == serviceName) {
+        success
+      } else {
+        val actions = getActions
+
+        actions.get(routingKey).orElse(actions.get("*")) match {
+          case Some(action) ⇒
+            val identity = getIdentities.getOrElse(origin, Identity(Set()))
+
+            val authorized =
+              identity.isMemberOfAny(action.permissions) || action.permissions.contains(origin) || action.permissions.contains("*")
+
+            if (!authorized) {
+              failure(s"Unauthorised sbus cmd: ${context.routingKey}, origin $origin")
+            } else {
+              success
+            }
+
+          case _ ⇒
+            failure(
+              s"No action defined for sbus cmd: ${context.routingKey}, origin $origin"
+            )
+        }
       }
 
-      val actions = getActions
+    }) getOrElse {
+      failure(
+        s"Unauthenticated sbus cmd: ${context.routingKey}, origin ${context.origin}"
+      )
+    }
 
-      actions.get(routingKey).orElse(actions.get("*")) match {
-        case Some(action) ⇒
-          val identity = getIdentities.getOrElse(caller, Identity(Set()))
+  }
 
-          val authorized =
-            identity.isMemberOfAny(action.permissions) || action.permissions.contains(caller) || action.permissions.contains("*")
+  override def verifyCommandSignature(context: Context, cmd: Option[Array[Byte]]) =
+    (for {
+      origin     ← context.get(Headers.Origin)
+      signature  ← context.get(Headers.Signature)
+      routingKey ← context.get(Headers.RoutingKey)
+      pubKey     ← getPublicKeys.get(origin)
+    } yield {
+      val edDSAEngine = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm))
+      edDSAEngine.initVerify(pubKey)
 
-          if (!authorized) {
-            failure(s"Unauthorised sbus request: ${context.routingKey}, caller $caller, ip ${context.ip}, message ${context.messageId}")
-          } else {
-            success
-          }
+      cmd foreach edDSAEngine.update
+      edDSAEngine.update(routingKey.getBytes)
+      edDSAEngine.update(origin.getBytes)
 
-        case _ ⇒
-          failure(
-            s"No action defined for sbus request: ${context.routingKey}, caller $caller, ip ${context.ip}, message ${context.messageId}"
-          )
+      if (!edDSAEngine.verify(Base64.getUrlDecoder.decode(signature.replace('+', '-').replace('/', '_')))) {
+        failure(
+          s"Signature invalid for sbus cmd: ${context.routingKey}, origin: $origin"
+        )
+      } else {
+        success
       }
     }) getOrElse {
       failure(
-        s"Unauthenticated sbus request: ${context.routingKey}, caller ${context.get(Headers.Origin)}, ip ${context.ip}, messageId ${context.messageId}"
+        s"Unauthenticated sbus cmd: ${context.routingKey}, origin: ${context.origin}"
       )
     }
+
+  override def signCommand(context: Context, cmd: Option[Any]) = {
+    if (context.get(Headers.ProxyPass).exists(_.toBoolean)) {
+      context
+    } else {
+      val edDSAEngine = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm))
+      edDSAEngine.initSign(privKey)
+
+      cmd map mapper.writeValueAsBytes foreach edDSAEngine.update
+      context.get(Headers.RoutingKey) foreach { routingKey ⇒ edDSAEngine.update(routingKey.getBytes) }
+      edDSAEngine.update(serviceName.getBytes)
+
+      val signature = Base64.getUrlEncoder.encodeToString(edDSAEngine.sign())
+
+      log.debug(s"Signing sbus cmd: ${context.routingKey}, origin $serviceName")
+
+      context
+        .withValue(Headers.Origin, serviceName)
+        .withValue(Headers.Signature, signature)
+    }
+  }
+
+  private def addMessageHeadersToEngine(context: Context, edDSAEngine: EdDSAEngine): Unit = {
+    context.get(Headers.Timestamp) foreach { timestamp ⇒ edDSAEngine.update(timestamp.getBytes) }
+    context.get(Headers.RoutingKey) foreach { value ⇒ edDSAEngine.update(value.getBytes) }
+    context.get(Headers.CorrelationId) foreach { value ⇒ edDSAEngine.update(value.getBytes) }
+  }
 
   private def getPublicKeys: Map[String, EdDSAPublicKey] =
     localPublicKeys ++ dynamicProvider.getPublicKeys
@@ -161,7 +219,9 @@ class AuthProviderImpl(val conf: Config, val mapper: ObjectMapper, val dynamicPr
 class NoopAuthProvider extends AuthProvider {
   private val success = Success {}
 
-  override def sign(context: Context, body: Array[Byte]): Context     = context
-  override def verify(context: Context, body: Array[Byte]): Try[Unit] = success
-  override def authorize(context: Context): Try[Unit]                 = success
+  override def signMessageRequest(context: Context, body: Array[Byte]): Context              = context
+  override def verifyMessageSignature(context: Context, body: Array[Byte]): Try[Unit]        = success
+  override def authorizeCommand(context: Context): Try[Unit]                                 = success
+  override def signCommand(context: Context, cmd: Option[Any]): Context                      = context
+  override def verifyCommandSignature(context: Context, cmd: Option[Array[Byte]]): Try[Unit] = success
 }

--- a/src/main/scala/com/sbuslab/sbus/javadsl/Sbus.scala
+++ b/src/main/scala/com/sbuslab/sbus/javadsl/Sbus.scala
@@ -5,9 +5,11 @@ import java.util.function.BiFunction
 import scala.compat.java8.FutureConverters._
 
 import com.sbuslab.sbus.{Context, Transport}
+import com.sbuslab.sbus.auth.AuthProvider
 
-
-class Sbus(transport: Transport) {
+class Sbus(transport: Transport, authProvider: AuthProvider) {
+  def sign(routingKey: String, message: Any): Context =
+    authProvider.signCommand(Context.empty.withRoutingKey(routingKey), Option(message));
 
   def request[T](routingKey: String, responseClass: Class[T]): CompletableFuture[T] =
     request(routingKey, null, responseClass, Context.empty)

--- a/src/main/scala/com/sbuslab/sbus/rabbitmq/RabbitMqTransport.scala
+++ b/src/main/scala/com/sbuslab/sbus/rabbitmq/RabbitMqTransport.scala
@@ -306,7 +306,7 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
             }).asInstanceOf[T]
 
             authProvider.verifyMessageSignature(context, delivery.body) flatMap { _ ⇒
-              authProvider.verifyCommandSignature(context, body.map(jsonWriter.writeValueAsBytes)) flatMap { _ ⇒
+              authProvider.verifyCommandSignature(context, body.map(mapper.writeValueAsBytes)) flatMap { _ ⇒
                 authProvider.authorizeCommand(context)
               }
             } recover { case e ⇒

--- a/src/main/scala/com/sbuslab/sbus/rabbitmq/RabbitMqTransport.scala
+++ b/src/main/scala/com/sbuslab/sbus/rabbitmq/RabbitMqTransport.scala
@@ -6,7 +6,7 @@ import java.util
 import java.util.UUID
 import java.util.concurrent._
 import scala.collection.JavaConverters._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 import scala.concurrent.duration._
 
 import akka.actor.{ActorRef, ActorSystem, Props}
@@ -28,10 +28,9 @@ import com.sbuslab.model._
 import com.sbuslab.sbus.{Context, Headers, Transport}
 import com.sbuslab.sbus.auth.AuthProvider
 
-
 class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: ActorSystem, mapper: ObjectMapper) extends Transport {
 
-  implicit val ec = actorSystem.dispatcher
+  implicit val ec: ExecutionContextExecutor = actorSystem.dispatcher
 
   private val log = Logger(LoggerFactory.getLogger("sbus.rabbitmq"))
 
@@ -42,7 +41,7 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
       mapper.writer()
     }
 
-  implicit val defaultTimeout = Timeout(conf.getDuration("default-timeout").toMillis, TimeUnit.MILLISECONDS)
+  implicit val defaultTimeout: Timeout = Timeout(conf.getDuration("default-timeout").toMillis, TimeUnit.MILLISECONDS)
 
   private val LogTrimLength         = conf.getInt("log-trim-length")
   private val UnloggedRequests      = conf.getStringList("unlogged-requests").asScala.toSet
@@ -53,50 +52,50 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
   private val rpcServers = new ConcurrentLinkedQueue[ActorRef]
 
   private val connection = actorSystem.actorOf(ConnectionOwner.props(
-    connFactory = {
-      log.debug("Sbus connecting to: " + conf.getString("host"))
+      connFactory       = {
+        log.debug("Sbus connecting to: " + conf.getString("host"))
 
-      val cf = new ConnectionFactory()
-      cf.setUsername(conf.getString("username"))
-      cf.setPassword(conf.getString("password"))
-      cf.setTopologyRecoveryEnabled(true)
+        val cf = new ConnectionFactory()
+        cf.setUsername(conf.getString("username"))
+        cf.setPassword(conf.getString("password"))
+        cf.setTopologyRecoveryEnabled(true)
 
-      if (conf.getBoolean("ssl.enabled")) {
-        val tks = KeyStore.getInstance("JKS")
+        if (conf.getBoolean("ssl.enabled")) {
+          val tks = KeyStore.getInstance("JKS")
 
         tks.load(new FileInputStream(
           conf.getString("ssl.truststore.certs-path")),
-          conf.getString("ssl.truststore.password").toCharArray
-        )
+            conf.getString("ssl.truststore.password").toCharArray
+          )
 
-        val tmf = TrustManagerFactory.getInstance("SunX509")
-        tmf.init(tks)
+          val tmf = TrustManagerFactory.getInstance("SunX509")
+          tmf.init(tks)
 
-        val sslContext = SSLContext.getInstance("TLSv1.2")
-        sslContext.init(null, tmf.getTrustManagers, null)
+          val sslContext = SSLContext.getInstance("TLSv1.2")
+          sslContext.init(null, tmf.getTrustManagers, null)
 
-        cf.useSslProtocol(sslContext)
-      }
+          cf.useSslProtocol(sslContext)
+        }
 
-      cf.setTopologyRecoveryRetryHandler(TopologyRecoveryRetryHandlerBuilder.builder()
-        .bindingRecoveryRetryCondition((_, _) ⇒ true)
-        .consumerRecoveryRetryCondition((_, _) ⇒ true)
-        .exchangeRecoveryRetryCondition((_, _) ⇒ true)
-        .queueRecoveryRetryCondition((_, _) ⇒ true)
-        .retryAttempts(Int.MaxValue)
-        .backoffPolicy(_ ⇒ Thread.sleep(100))
-        .build())
+        cf.setTopologyRecoveryRetryHandler(TopologyRecoveryRetryHandlerBuilder.builder()
+          .bindingRecoveryRetryCondition((_, _) ⇒ true)
+          .consumerRecoveryRetryCondition((_, _) ⇒ true)
+          .exchangeRecoveryRetryCondition((_, _) ⇒ true)
+          .queueRecoveryRetryCondition((_, _) ⇒ true)
+          .retryAttempts(Int.MaxValue)
+          .backoffPolicy(_ ⇒ Thread.sleep(100))
+          .build())
 
-      cf.setAutomaticRecoveryEnabled(true)
-      cf.setNetworkRecoveryInterval(5000)
-      cf.setRequestedHeartbeat(10)
-      cf.setConnectionTimeout(5000)
-      cf
-    },
-    reconnectionDelay = 3.seconds,
-    addressResolver = Some(new ListAddressResolver(
-      conf.getString("host").split(',').map(host ⇒ new Address(host, conf.getInt("port"))).toList.asJava
-    ))
+        cf.setAutomaticRecoveryEnabled(true)
+        cf.setNetworkRecoveryInterval(5000)
+        cf.setRequestedHeartbeat(10)
+        cf.setConnectionTimeout(5000)
+        cf
+      },
+      reconnectionDelay = 3.seconds,
+      addressResolver   = Some(new ListAddressResolver(
+        conf.getString("host").split(',').map(host ⇒ new Address(host, conf.getInt("port"))).toList.asJava
+      ))
   ), name = "rabbitmq-connection")
 
   private val channelConfigs: Map[String, SbusChannel] = {
@@ -110,13 +109,13 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
       val retryExchange = Amqp.ExchangeParameters(exchange.name + "-retries", passive = false, exchangeType = "fanout")
 
       Await.ready(for {
-        _ ← producer ? Amqp.DeclareExchange(exchange) zip
+          _ ← producer ? Amqp.DeclareExchange(exchange) zip
             producer ? Amqp.DeclareExchange(retryExchange)
 
-        _ ← producer ? Amqp.DeclareQueue(
+          _ ← producer ? Amqp.DeclareQueue(
             Amqp.QueueParameters(retryExchange.name, passive = false, durable = true, exclusive = false, autodelete = false, args = Map("x-dead-letter-exchange" → exchange.name)))
 
-        _ ← producer ? Amqp.QueueBind(retryExchange.name, retryExchange.name, Set("#"))
+          _ ← producer ? Amqp.QueueBind(retryExchange.name, retryExchange.name, Set("#"))
       } yield {}, 120.seconds)
 
       name → SbusChannel(
@@ -142,16 +141,16 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
     child
   }
 
-  private val breakers = new ConcurrentHashMap[String, CircuitBreaker]()
+  private val breakers              = new ConcurrentHashMap[String, CircuitBreaker]()
   private val circuitBreakerEnabled = conf.getBoolean("circuit-breaker.enabled")
 
   private def circuitBreaker[T](routingKey: String)(f: ⇒ Future[T]): Future[T] =
     if (circuitBreakerEnabled) {
       breakers.computeIfAbsent(routingKey, _ ⇒ {
-        new CircuitBreaker(
-          scheduler    = actorSystem.scheduler,
-          maxFailures  = conf.getInt("circuit-breaker.max-failures"),
-          callTimeout  = Duration.Zero,
+          new CircuitBreaker(
+            scheduler    = actorSystem.scheduler,
+            maxFailures  = conf.getInt("circuit-breaker.max-failures"),
+            callTimeout  = Duration.Zero,
           resetTimeout = conf.getDuration("circuit-breaker.reset-timeout").toMillis.millis)
       }).withCircuitBreaker(f)
     } else f
@@ -179,14 +178,19 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
    *
    */
   def send(routingKey: String, msg: Any, context: Context, responseClass: Class[_]): Future[Any] = {
-    val channel = getChannel(routingKey)
+    val channel        = getChannel(routingKey)
     val realRoutingKey = routingKey.split(':').last // remove channel name prefix, if exists
 
     val bytes  = jsonWriter.writeValueAsBytes(new Message(realRoutingKey, msg))
     val corrId = Option(context.correlationId).getOrElse(UUID.randomUUID().toString)
     val time   = System.currentTimeMillis()
 
-    implicit val ctx: Context = authProvider.sign(context.withValue(Headers.Timestamp, time.toString), bytes)
+    implicit val ctx: Context = authProvider.signMessageRequest(
+      authProvider.signCommand(context.withValue(Headers.Timestamp, time.toString)
+          .withCorrelationId(corrId)
+          .withRoutingKey(realRoutingKey), Option(msg)),
+      bytes
+    )
 
     val propsBldr = new BasicProperties().builder()
       .deliveryMode(if (responseClass != null) 1 else 2) // 2 → persistent
@@ -197,17 +201,20 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
         case _                          ⇒ null
       })
       .headers(Map(
-        Headers.CorrelationId    → corrId,
-        Headers.RoutingKey       → realRoutingKey,
-        Headers.RetryAttemptsMax → ctx.maxRetries.getOrElse(if (responseClass != null) null else DefaultCommandRetries), // commands retryable by default
+        Headers.CorrelationId    → ctx.correlationId,
+        Headers.RoutingKey       → ctx.routingKey,
+        // commands retryable by default
+        Headers.RetryAttemptsMax → ctx.maxRetries.getOrElse(if (responseClass != null) null else DefaultCommandRetries),
         Headers.ExpiredAt        → ctx.timeout.map(_ + time).getOrElse(null),
-        Headers.Timestamp        → time,
+        Headers.Timestamp        → ctx.get(Headers.Timestamp).orNull,
         Headers.Ip               → ctx.ip,
         Headers.UserAgent        → ctx.userAgent,
-        Headers.Origin           → ctx.get(Headers.Origin).orNull,
         Headers.UserId           → ctx.get(Headers.UserId).orNull,
         Headers.Auth             → ctx.get(Headers.Auth).orNull,
+        Headers.Origin           → ctx.get(Headers.Origin).orNull,
         Headers.Signature        → ctx.get(Headers.Signature).orNull,
+        Headers.MessageOrigin    → ctx.get(Headers.MessageOrigin).orNull,
+        Headers.MessageSignature → ctx.get(Headers.MessageSignature).orNull
       ).filter(_._2 != null).mapValues(_.toString.asInstanceOf[Object]).asJava)
 
     if (corrId != "sbus:ping") {
@@ -217,38 +224,38 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
     val pub = Amqp.Publish(channel.exchange, realRoutingKey, bytes, Some(propsBldr.build()), mandatory = channel.mandatory)
 
     (if (responseClass != null) {
-      circuitBreaker(realRoutingKey) {
-        rpcClient.ask(RpcClient.Request(pub))(ctx.timeout.fold(defaultTimeout)(_.millis)) map {
-          case RpcClient.Response(deliveries) ⇒
-            logs("resp <~~~", realRoutingKey, deliveries.head.body, corrId)
+       circuitBreaker(realRoutingKey) {
+         rpcClient.ask(RpcClient.Request(pub))(ctx.timeout.fold(defaultTimeout)(_.millis)) map {
+           case RpcClient.Response(deliveries) ⇒
+             logs("resp <~~~", realRoutingKey, deliveries.head.body, corrId)
 
-            val tree = mapper.readTree(deliveries.head.body)
+             val tree = mapper.readTree(deliveries.head.body)
 
-            val status =
-              if (tree.hasNonNull("status")) {
-                tree.path("status").asInt
-              } else if (tree.path("failed").asBoolean(false)) { // backward compatibility with old protocol
-                500
-              } else { 200 }
+             val status =
+               if (tree.hasNonNull("status")) {
+                 tree.path("status").asInt
+               } else if (tree.path("failed").asBoolean(false)) { // backward compatibility with old protocol
+                 500
+               } else { 200 }
 
-            if (status < 400) {
-              deserializeToClass(tree.path("body"), responseClass)
-            } else {
-              val err = mapper.treeToValue(tree.path("body"), classOf[ErrorResponseBody])
-              throw ErrorMessage.fromCode(status, err.getMessage, null, err.getError, err.getLinks, err.getEmbedded)
-            }
+             if (status < 400) {
+               deserializeToClass(tree.path("body"), responseClass)
+             } else {
+               val err = mapper.treeToValue(tree.path("body"), classOf[ErrorResponseBody])
+               throw ErrorMessage.fromCode(status, err.getMessage, null, err.getError, err.getLinks, err.getEmbedded)
+             }
 
-          case other ⇒
-            log.error(s"Unexpected response for `$realRoutingKey`: $other")
-            throw new InternalServerError(s"Unexpected response for `$realRoutingKey`")
-        }
-      }
-    } else {
-      channel.producer ? pub map {
-        case _: Amqp.Ok ⇒ // ok
-        case error ⇒ throw new InternalServerError("Error on publish message to " + realRoutingKey + ": " + error)
-      }
-    }) recover {
+           case other ⇒
+             log.error(s"Unexpected response for `$realRoutingKey`: $other")
+             throw new InternalServerError(s"Unexpected response for `$realRoutingKey`")
+         }
+       }
+     } else {
+       channel.producer ? pub map {
+         case _: Amqp.Ok ⇒ // ok
+         case error      ⇒ throw new InternalServerError("Error on publish message to " + realRoutingKey + ": " + error)
+       }
+     }) recover {
       case e: AskTimeoutException ⇒
         logs("timeout error", realRoutingKey, bytes, corrId, e)
         throw new ErrorMessage(504, s"Timeout on `$realRoutingKey` with message ${if (msg != null) msg.getClass.getSimpleName else null}", e)
@@ -275,12 +282,12 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
       return
     }
 
-    val channel = getChannel(routingKey)
+    val channel          = getChannel(routingKey)
     val subscriptionName = routingKey.split(':').last
 
     val processor = new RpcServer.IProcessor {
       def process(delivery: Amqp.Delivery): Future[RpcServer.ProcessResult] = {
-        implicit val context = Context.from(delivery)
+        implicit val context: Context = Context.from(delivery)
 
         if (context.correlationId == "sbus:ping") {
           val pingAt = mapper.readTree(delivery.body).path("body").path("ping").asLong(0)
@@ -292,13 +299,16 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
           (try {
             logs("<~~~", subscriptionName, delivery.body, context.correlationId)
 
-            val payload = (Option(mapper.readTree(delivery.body)).map(_.get("body")).orNull match {
+            val body    = Option(mapper.readTree(delivery.body).get("body"))
+            val payload = (body.orNull match {
               case null ⇒ null
               case body ⇒ deserializeToClass(body, messageClass)
             }).asInstanceOf[T]
 
-            authProvider.verify(context, delivery.body) flatMap { _ ⇒
-              authProvider.authorize(context)
+            authProvider.verifyMessageSignature(context, delivery.body) flatMap { _ ⇒
+              authProvider.verifyCommandSignature(context, body.map(jsonWriter.writeValueAsBytes)) flatMap { _ ⇒
+                authProvider.authorizeCommand(context)
+              }
             } recover { case e ⇒
               logs("auth error", subscriptionName, delivery.body, context.correlationId, e)
               throw new UnauthorizedError("Sbus message can not be verified or authorized", e)
@@ -332,7 +342,7 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
               if (attemptsMax.exists(_ >= attemptNr)) {
                 heads.put(Headers.RetryAttemptNr, s"${attemptNr + 1}")
 
-                val backoff = math.pow(2, math.min(attemptNr - 1, 6)).round * 1000  // max 64 seconds
+                val backoff = math.pow(2, math.min(attemptNr - 1, 6)).round * 1000 // max 64 seconds
 
                 val updProps = delivery.properties.builder()
                   .headers(heads)
@@ -357,13 +367,13 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
           } recover {
             case e @ (_: CompletionException | _: ExecutionException) if e.getCause != null ⇒ onFailure(delivery, e.getCause)
             case e: RuntimeException if e.getCause != null && !e.isInstanceOf[ErrorMessage] ⇒ onFailure(delivery, e.getCause)
-            case e: Throwable ⇒ onFailure(delivery, e)
+            case e: Throwable                                                               ⇒ onFailure(delivery, e)
           }
         }
       }
 
       def onFailure(delivery: Amqp.Delivery, e: Throwable): RpcServer.ProcessResult = {
-        implicit val context = Context.from(delivery)
+        implicit val context: Context = Context.from(delivery)
 
         logs("error", subscriptionName, e.toString.getBytes, context.correlationId, e)
 
@@ -383,8 +393,8 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
     }
 
     val binding = Amqp.AddBinding(Amqp.Binding(
-      exchange = Amqp.ExchangeParameters(channel.exchange, passive = false, exchangeType = channel.exchangeType),
-      queue = Amqp.QueueParameters(
+      exchange    = Amqp.ExchangeParameters(channel.exchange, passive = false, exchangeType = channel.exchangeType),
+      queue       = Amqp.QueueParameters(
         name       = channel.queueNameFormat.format(subscriptionName),
         passive    = false,
         durable    = channel.durable,
@@ -399,38 +409,38 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
 
     def createRpcActor(): Unit = {
       val rpcServer = ConnectionOwner.createChildActor(connection, Props(new RpcServer(
-        processor = processor,
-        init = List(binding),
-        channelParams = Some(ChannelParams)
-      ) {
-        override def connected(channel: Channel, forwarder: ActorRef): Receive = LoggingReceive({
-          case Amqp.ConsumerCancelled(consumerTag) ⇒
-            log.warning(s"Sbus consumer for $routingKey cancelled ($consumerTag), trying to shutdown it and connect again...")
-            self forward Amqp.Shutdown(new ShutdownSignalException(true, false, null, null))
+          processor     = processor,
+          init          = List(binding),
+          channelParams = Some(ChannelParams)
+        ) {
+          override def connected(channel: Channel, forwarder: ActorRef): Receive = LoggingReceive({
+            case Amqp.ConsumerCancelled(consumerTag) ⇒
+              log.warning(s"Sbus consumer for $routingKey cancelled ($consumerTag), trying to shutdown it and connect again...")
+              self forward Amqp.Shutdown(new ShutdownSignalException(true, false, null, null))
 
-            actorSystem.stop(self)
+              actorSystem.stop(self)
 
-            createRpcActor() // recreate
+              createRpcActor() // recreate
 
-          case Amqp.Shutdown(cause) if !cause.isInitiatedByApplication ⇒
-            context.stop(forwarder)
+            case Amqp.Shutdown(cause) if !cause.isInitiatedByApplication ⇒
+              context.stop(forwarder)
 
-            if (!cause.isHardError) {
-              context.parent ! ConnectionOwner.CreateChannel
-            }
+              if (!cause.isHardError) {
+                context.parent ! ConnectionOwner.CreateChannel
+              }
 
-            statusListeners.foreach(_ ! ChannelOwner.Disconnected)
-            context.become(disconnected)
+              statusListeners.foreach(_ ! ChannelOwner.Disconnected)
+              context.become(disconnected)
 
-        }: Receive) orElse super.connected(channel, forwarder)
+          }: Receive) orElse super.connected(channel, forwarder)
 
-        override def unhandled(message: Any): Unit = message match {
-          case Amqp.Shutdown(cause) ⇒
-            log.debug(s"Amqp.Shutdown $cause")
+          override def unhandled(message: Any): Unit = message match {
+            case Amqp.Shutdown(cause) ⇒
+              log.debug(s"Amqp.Shutdown $cause")
 
-          case _ ⇒
-            super.unhandled(message)
-        }
+            case _ ⇒
+              super.unhandled(message)
+          }
       }))
 
       log.debug(s"Sbus subscribed to: $subscriptionName / $channel")

--- a/src/test/scala/com/sbuslab/sbus/AuthProviderImplTest.scala
+++ b/src/test/scala/com/sbuslab/sbus/AuthProviderImplTest.scala
@@ -3,7 +3,7 @@ package com.sbuslab.sbus
 import scala.language.postfixOps
 
 import java.security.MessageDigest
-import java.util.Base64
+import java.util.{Base64, UUID}
 import scala.collection.JavaConverters._
 import scala.util
 import scala.util.{Failure, Success, Try}
@@ -11,6 +11,7 @@ import scala.util.{Failure, Success, Try}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import net.i2p.crypto.eddsa.{EdDSAEngine, EdDSAPrivateKey, EdDSAPublicKey, KeyPairGenerator, Utils}
+import org.hibernate.validator.internal.util.stereotypes.Immutable
 import org.junit.runner.RunWith
 import org.mockito.Mockito.when
 import org.scalatest.{AsyncWordSpec, Matchers}
@@ -77,7 +78,12 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       mockDynamicProvider
     )
 
-    def sign(context: Context, body: Array[Byte], serviceName: String, privKey: EdDSAPrivateKey, timestamp: Array[Byte]): Context = {
+    def signMessageRequest(
+      context: Context,
+      body: Array[Byte],
+      serviceName: String,
+      privKey: EdDSAPrivateKey,
+      timestamp: Array[Byte]): Context = {
       val signer = new EdDSAEngine(MessageDigest.getInstance(underTest.spec.getHashAlgorithm))
       signer.initSign(privKey)
 
@@ -85,16 +91,59 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       signer.update(timestamp)
 
       context
+        .withValue(Headers.MessageOrigin, serviceName)
+        .withValue(Headers.MessageSignature, Base64.getUrlEncoder.encodeToString(signer.sign()))
+    }
+
+    def signCommand(
+      context: Context,
+      body: Array[Byte],
+      serviceName: String,
+      privKey: EdDSAPrivateKey,
+      routingKey: Array[Byte]): Context = {
+      val signer = new EdDSAEngine(MessageDigest.getInstance(underTest.spec.getHashAlgorithm))
+      signer.initSign(privKey)
+
+      signer.update(body)
+      signer.update(routingKey)
+      signer.update(serviceName.getBytes)
+
+      context
         .withValue(Headers.Origin, serviceName)
         .withValue(Headers.Signature, Base64.getUrlEncoder.encodeToString(signer.sign()))
     }
 
-    def verify(signature: Array[Byte], body: Array[Byte], pubKey: EdDSAPublicKey, timestamp: Array[Byte]): Boolean = {
+    def verifyMessageSignature(
+      signature: Array[Byte],
+      body: Array[Byte],
+      pubKey: EdDSAPublicKey,
+      timestamp: Array[Byte],
+      routingKey: Array[Byte],
+      correlationId: Array[Byte]): Boolean = {
+
       val vrf = new EdDSAEngine(MessageDigest.getInstance(underTest.spec.getHashAlgorithm))
       vrf.initVerify(pubKey)
 
       vrf.update(body)
       vrf.update(timestamp)
+      vrf.update(routingKey)
+      vrf.update(correlationId)
+
+      vrf.verify(signature)
+    }
+
+    def verifyCommand(
+      signature: Array[Byte],
+      body: Array[Byte],
+      pubKey: EdDSAPublicKey,
+      routingKey: Array[Byte],
+      serviceName: Array[Byte]): Boolean = {
+      val vrf = new EdDSAEngine(MessageDigest.getInstance(underTest.spec.getHashAlgorithm))
+      vrf.initVerify(pubKey)
+
+      vrf.update(body)
+      vrf.update(routingKey)
+      vrf.update(serviceName)
 
       vrf.verify(signature)
     }
@@ -102,26 +151,145 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
   }
 
   "ConsulProvider" should {
+    "sign commands" in {
+      val test = TestSuite()
+
+      when(test.mockDynamicProvider.getPublicKeys).thenReturn(Map[String, EdDSAPublicKey]())
+
+      val body       = "{}".getBytes
+      val routingKey = "system.event"
+      val context    = Context.empty
+        .withRoutingKey(routingKey)
+
+      val result = test.underTest.signCommand(context, body)
+
+      result.get(Headers.Origin).get should equal(test.underTest.serviceName)
+      result.get(Headers.Signature) should not be null
+
+      val verified = test.verifyCommand(
+        result.get(Headers.Signature).map(sig ⇒ Base64.getUrlDecoder.decode(sig.replace('+', '-').replace('/', '_'))).get,
+        body,
+        test.keyPair.getPublic.asInstanceOf[EdDSAPublicKey],
+        routingKey.getBytes,
+        test.underTest.serviceName.getBytes
+      )
+
+      verified shouldBe true
+    }
+
+    "not resign commands if proxy pass" in {
+      val test = TestSuite()
+
+      when(test.mockDynamicProvider.getPublicKeys).thenReturn(Map[String, EdDSAPublicKey]())
+
+      val body       = "{}".getBytes
+      val routingKey = "system.event"
+      val context    = Context.empty
+        .withRoutingKey(routingKey)
+        .withValue(Headers.ProxyPass, true)
+        .withValue(Headers.Signature, "fakesig")
+        .withValue(Headers.Origin, "fakeorigin")
+
+      val result = test.underTest.signCommand(context, body)
+
+      result.get(Headers.Origin).get should equal("fakeorigin")
+      result.get(Headers.Signature).get should equal("fakesig")
+    }
+
+    "sign and verify commands" in {
+      val test = TestSuite()
+
+      when(test.mockDynamicProvider.getPublicKeys).thenReturn(Map[String, EdDSAPublicKey]())
+
+      val body    = "{}".getBytes
+      val context = Context.empty
+        .withRoutingKey("system.event")
+
+      val result = test.underTest.signCommand(context, body)
+
+      result.get(Headers.Origin).get should equal(test.underTest.serviceName)
+      result.get(Headers.Signature) should not be null
+
+      val verified = test.underTest.verifyCommandSignature(result, body)
+
+      verified shouldBe a[Success[_]]
+    }
+
+    "not verify commands with the wrong key pair with required true" in {
+      val test = TestSuite()
+
+      when(test.mockDynamicProvider.getPublicKeys).thenReturn(Map[String, EdDSAPublicKey]())
+
+      val body       = "{}".getBytes
+      val routingKey = "system.event"
+      val context    = Context.empty
+        .withRoutingKey(routingKey)
+
+      val signed =
+        test.signCommand(
+          context,
+          body,
+          "services/my-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          routingKey.getBytes
+        )
+
+      val verified = test.underTest.verifyCommandSignature(signed, body)
+
+      verified shouldBe a[Failure[_]]
+    }
+
+    "not verify commands with the wrong key pair with required false" in {
+      val test = TestSuite(required = false)
+
+      when(test.mockDynamicProvider.getPublicKeys).thenReturn(Map[String, EdDSAPublicKey]())
+      when(test.mockDynamicProvider.isRequired).thenReturn(false)
+
+      val body       = "{}".getBytes
+      val routingKey = "system.event"
+      val context    = Context.empty
+        .withRoutingKey(routingKey)
+
+      val signed =
+        test.signCommand(
+          context,
+          body,
+          "services/my-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          routingKey.getBytes
+        )
+
+      val verified = test.underTest.verifyCommandSignature(signed, body)
+
+      verified shouldBe a[Success[_]]
+    }
+
     "sign messages" in {
       val test = TestSuite()
 
       when(test.mockDynamicProvider.getPublicKeys).thenReturn(Map[String, EdDSAPublicKey]())
 
-      val body      = "{}".getBytes
-      val timestamp = System.currentTimeMillis().toString
-      val context   = Context.empty
+      val routingKey    = "route.main"
+      val correlationId = UUID.randomUUID.toString
+      val body          = "{}".getBytes
+      val timestamp     = System.currentTimeMillis().toString
+      val context       = Context.empty
         .withValue(Headers.Timestamp, timestamp)
+        .withValue(Headers.RoutingKey, routingKey)
+        .withValue(Headers.CorrelationId, correlationId)
 
-      val result = test.underTest.sign(context, body)
+      val result = test.underTest.signMessageRequest(context, body)
 
-      result.get(Headers.Origin).get should equal(test.underTest.serviceName)
-      result.get(Headers.Signature) should not be null
+      result.get(Headers.MessageOrigin).get should equal(test.underTest.serviceName)
+      result.get(Headers.MessageSignature) should not be null
 
-      val verified = test.verify(
-        result.get(Headers.Signature).map(sig ⇒ Base64.getUrlDecoder.decode(sig.replace('+', '-').replace('/', '_'))).get,
+      val verified = test.verifyMessageSignature(
+        result.get(Headers.MessageSignature).map(sig ⇒ Base64.getUrlDecoder.decode(sig.replace('+', '-').replace('/', '_'))).get,
         body,
         test.keyPair.getPublic.asInstanceOf[EdDSAPublicKey],
-        timestamp.getBytes
+        timestamp.getBytes,
+        routingKey.getBytes,
+        correlationId.getBytes,
       )
 
       verified shouldBe true
@@ -137,14 +305,14 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       val context   = Context.empty
         .withValue(Headers.Timestamp, timestamp)
 
-      val result = test.underTest.sign(context, body)
+      val result = test.underTest.signMessageRequest(context, body)
 
-      result.get(Headers.Origin).get should equal(test.underTest.serviceName)
-      result.get(Headers.Signature) should not be null
+      result.get(Headers.MessageOrigin).get should equal(test.underTest.serviceName)
+      result.get(Headers.MessageSignature) should not be null
 
-      val verified = test.underTest.verify(result, body)
+      val verified = test.underTest.verifyMessageSignature(result, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "verify messages with the right key pair" in {
@@ -158,11 +326,17 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Timestamp, timestamp)
 
       val signed =
-        test.sign(context, body, "services/other-service", test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+        test.signMessageRequest(
+          context,
+          body,
+          "services/other-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          timestamp.getBytes
+        )
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "not verify messages with the wrong key pair with required true" in {
@@ -177,11 +351,17 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Timestamp, timestamp)
 
       val signed =
-        test.sign(context, body, "services/my-service", test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+        test.signMessageRequest(
+          context,
+          body,
+          "services/my-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          timestamp.getBytes
+        )
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Failure[Unit]]
+      verified shouldBe a[Failure[_]]
     }
 
     "verify messages with the wrong key pair with required false" in {
@@ -197,11 +377,17 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Timestamp, timestamp)
 
       val signed =
-        test.sign(context, body, "services/my-service", test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+        test.signMessageRequest(
+          context,
+          body,
+          "services/my-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          timestamp.getBytes
+        )
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "not verify messages with no key pair with required true" in {
@@ -216,11 +402,17 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Timestamp, timestamp)
 
       val signed =
-        test.sign(context, body, "services/random-service", test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+        test.signMessageRequest(
+          context,
+          body,
+          "services/random-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          timestamp.getBytes
+        )
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Failure[Unit]]
+      verified shouldBe a[Failure[_]]
     }
 
     "verify messages with no key pair with required false" in {
@@ -236,11 +428,17 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Timestamp, timestamp)
 
       val signed =
-        test.sign(context, body, "services/random-service", test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+        test.signMessageRequest(
+          context,
+          body,
+          "services/random-service",
+          test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey],
+          timestamp.getBytes
+        )
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "not verify messages with no origin with required true" in {
@@ -254,11 +452,11 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       val context = Context.empty
         .withValue(Headers.Timestamp, timestamp)
 
-      val signed = test.sign(context, body, null, test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+      val signed = test.signMessageRequest(context, body, null, test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Failure[Unit]]
+      verified shouldBe a[Failure[_]]
     }
 
     "verify messages with no origin with required false" in {
@@ -273,11 +471,11 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       val context = Context.empty
         .withValue(Headers.Timestamp, timestamp)
 
-      val signed = test.sign(context, body, null, test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
+      val signed = test.signMessageRequest(context, body, null, test.keyPair2.getPrivate.asInstanceOf[EdDSAPrivateKey], timestamp.getBytes)
 
-      val verified = test.underTest.verify(signed, body)
+      val verified = test.underTest.verifyMessageSignature(signed, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "not verify messages with no signature with required true" in {
@@ -287,11 +485,11 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
 
       val body    = "{}".getBytes
       val context = Context.empty
-        .withValue(Headers.Origin, "services/other-service")
+        .withValue(Headers.MessageOrigin, "services/other-service")
 
-      val verified = test.underTest.verify(context, body)
+      val verified = test.underTest.verifyMessageSignature(context, body)
 
-      verified shouldBe a [Failure[Unit]]
+      verified shouldBe a[Failure[_]]
     }
 
     "verify messages with no signature with required false" in {
@@ -302,11 +500,11 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
 
       val body    = "{}".getBytes
       val context = Context.empty
-        .withValue(Headers.Origin, "services/other-service")
+        .withValue(Headers.MessageOrigin, "services/other-service")
 
-      val verified = test.underTest.verify(context, body)
+      val verified = test.underTest.verifyMessageSignature(context, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "verify messages with no signature with required false by dynamic is true" in {
@@ -317,11 +515,11 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
 
       val body    = "{}".getBytes
       val context = Context.empty
-        .withValue(Headers.Origin, "services/other-service")
+        .withValue(Headers.MessageOrigin, "services/other-service")
 
-      val verified = test.underTest.verify(context, body)
+      val verified = test.underTest.verifyMessageSignature(context, body)
 
-      verified shouldBe a [Failure[Unit]]
+      verified shouldBe a[Failure[_]]
     }
 
     "authorize messages when origin is self" in {
@@ -334,9 +532,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "services/my-service")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when origin is authorized by being a memberOf  by specific action" in {
@@ -349,9 +547,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/joe.bloggs")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when origin is authorized directly by specific action" in {
@@ -364,9 +562,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.create-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when origin is authorized by action by wildcard" in {
@@ -379,9 +577,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.update-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when unknown origin is authorized by action by wildcard" in {
@@ -394,9 +592,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/foo.bar")
         .withValue(Headers.RoutingKey, "users.update-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when origin is authorized by wildcard for action and permission" in {
@@ -409,9 +607,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.find-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "deny messages when origin is not authorized by specific action" in {
@@ -424,9 +622,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Failure[Unit]]
+      authorized shouldBe a[Failure[_]]
     }
 
     "authorize messages when origin is authorized by dynamic provider with a new action" in {
@@ -439,9 +637,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when origin is authorized by dynamic provider with a new identity" in {
@@ -454,9 +652,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "authorize messages when origin is not authorized by specific action when required is off" in {
@@ -470,9 +668,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Success[Unit]]
+      authorized shouldBe a[Success[_]]
     }
 
     "deny messages when origin is not authorized by specific action when required is dynamically on" in {
@@ -486,9 +684,9 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
         .withValue(Headers.Origin, "users/sarah.dene")
         .withValue(Headers.RoutingKey, "users.delete-user")
 
-      val authorized = test.underTest.authorize(context)
+      val authorized = test.underTest.authorizeCommand(context)
 
-      authorized shouldBe a [Failure[Unit]]
+      authorized shouldBe a[Failure[_]]
     }
 
     "verifies javascript generated signatures" in {
@@ -499,13 +697,13 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       val body      = "{}".getBytes
       val timestamp = "1655829081471"
       val context   = Context.empty
-        .withValue(Headers.Origin, "services/javascript-service")
-        .withValue(Headers.Signature, "tC2YsPMhL0WnHkwDdGDjuOdku3ACIBXfZwyUXhLCiIDt50HqzB4cyOkZtlwvF2ZD0IMYnAWszzv5--O1C5LLCQ")
+        .withValue(Headers.MessageOrigin, "services/javascript-service")
+        .withValue(Headers.MessageSignature, "tC2YsPMhL0WnHkwDdGDjuOdku3ACIBXfZwyUXhLCiIDt50HqzB4cyOkZtlwvF2ZD0IMYnAWszzv5--O1C5LLCQ")
         .withValue(Headers.Timestamp, timestamp)
 
-      val verified = test.underTest.verify(context, body)
+      val verified = test.underTest.verifyMessageSignature(context, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
 
     "verifies cli generated signatures" in {
@@ -517,13 +715,13 @@ class AuthProviderImplTest extends AsyncWordSpec with Matchers with MockitoSugar
       val timestamp = "1655826239963"
       val origin    = "services/cli-service"
       val context   = Context.empty
-        .withValue(Headers.Origin, origin)
-        .withValue(Headers.Signature, "N5Q31CHmWtZ4YDhXxJlTU_-s_yb0yIBEn3R5hB69syta6XC8n__kSrXabQ7Jdf3YMpQlzQAWZwDnuDdrKmM8AQ==")
+        .withValue(Headers.MessageOrigin, origin)
+        .withValue(Headers.MessageSignature, "N5Q31CHmWtZ4YDhXxJlTU_-s_yb0yIBEn3R5hB69syta6XC8n__kSrXabQ7Jdf3YMpQlzQAWZwDnuDdrKmM8AQ==")
         .withValue(Headers.Timestamp, timestamp)
 
-      val verified = test.underTest.verify(context, body)
+      val verified = test.underTest.verifyMessageSignature(context, body)
 
-      verified shouldBe a [Success[Unit]]
+      verified shouldBe a[Success[_]]
     }
   }
 }


### PR DESCRIPTION
This does two main things, splits command verification and authorization with message verification

This is so we can pass commands through the service bus if needed whilst ensuring each service in the chain is allowed to be part of it