### PR TITLE
PRIM-32 Refactor actions and identities to be nested sets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ dependencies {
 
     implementation 'net.i2p.crypto:eddsa:0.3.0'
 
+    implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.13.3'
+
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.scalatest:scalatest_2.12:3.0.5'
     testImplementation 'org.mockito:mockito-core:3.6.28'

--- a/src/main/scala/com/sbuslab/sbus/Sbus.scala
+++ b/src/main/scala/com/sbuslab/sbus/Sbus.scala
@@ -3,12 +3,15 @@ package com.sbuslab.sbus
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import com.sbuslab.model.Message
 import com.sbuslab.sbus.auth.AuthProvider
 
-class Sbus(transport: Transport, authProvider: AuthProvider)(implicit ec: ExecutionContext) {
+class Sbus(transport: Transport, authProvider: AuthProvider, objectMapper: ObjectMapper)(implicit ec: ExecutionContext) {
+
   def sign(routingKey: String, message: Message): Context =
-    authProvider.signCommand(Context.empty.withRoutingKey(routingKey), message);
+    authProvider.signCommand(Context.empty.withRoutingKey(routingKey), objectMapper.writeValueAsBytes(message))
 
   def request[T](routingKey: String, msg: Any = null)(implicit context: Context = Context.empty, tag: ClassTag[T]): Future[T] =
     transport.send(routingKey, msg, context, tag.runtimeClass).mapTo[T]

--- a/src/main/scala/com/sbuslab/sbus/auth/Identity.scala
+++ b/src/main/scala/com/sbuslab/sbus/auth/Identity.scala
@@ -1,9 +1,9 @@
 package com.sbuslab.sbus.auth
 
-case class Identity(memberOf: Set[String]) {
+case class Identity(groups: Set[String]) {
   def isMember(group: String): Boolean =
-    memberOf.contains(group)
+    groups.contains(group)
 
-  def isMemberOfAny(groups: Set[String]): Boolean =
-    memberOf.intersect(groups).nonEmpty
+  def isMemberOfAny(others: Set[String]): Boolean =
+    groups.intersect(others).nonEmpty
 }

--- a/src/main/scala/com/sbuslab/sbus/javadsl/Sbus.scala
+++ b/src/main/scala/com/sbuslab/sbus/javadsl/Sbus.scala
@@ -4,13 +4,15 @@ import java.util.concurrent.CompletableFuture
 import java.util.function.BiFunction
 import scala.compat.java8.FutureConverters._
 
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import com.sbuslab.model.Message
 import com.sbuslab.sbus.{Context, Transport}
 import com.sbuslab.sbus.auth.AuthProvider
 
-class Sbus(transport: Transport, authProvider: AuthProvider) {
+class Sbus(transport: Transport, authProvider: AuthProvider, mapper: ObjectMapper) {
   def sign(routingKey: String, message: Message): Context =
-    authProvider.signCommand(Context.empty.withRoutingKey(routingKey), message);
+    authProvider.signCommand(Context.empty.withRoutingKey(routingKey), mapper.writeValueAsBytes(message));
 
   def request[T](routingKey: String, responseClass: Class[T]): CompletableFuture[T] =
     request(routingKey, null, responseClass, Context.empty)

--- a/src/main/scala/com/sbuslab/sbus/rabbitmq/RabbitMqTransport.scala
+++ b/src/main/scala/com/sbuslab/sbus/rabbitmq/RabbitMqTransport.scala
@@ -211,7 +211,7 @@ class RabbitMqTransport(conf: Config, authProvider: AuthProvider, actorSystem: A
       context.withValue(Headers.Timestamp, time.toString)
         .withCorrelationId(corrId)
         .withRoutingKey(realRoutingKey),
-      message
+      bytes
     )
 
     val propsBuilder = new BasicProperties().builder()

--- a/src/test/scala/com/sbuslab/sbus/auth/providers/ConsulAuthConfigProviderTest.scala
+++ b/src/test/scala/com/sbuslab/sbus/auth/providers/ConsulAuthConfigProviderTest.scala
@@ -1,6 +1,5 @@
 package com.sbuslab.sbus.auth.providers
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
@@ -43,8 +42,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
     val underTest = new ConsulAuthConfigProvider(
       ConfigFactory
         .parseString(config)
-        .resolve(),
-      new ObjectMapper()
+        .resolve()
     )
 
     server.resetAll()
@@ -56,7 +54,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
       val test = TestSuite()
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.configPath}")).willReturn(
-        okJson("{\"actions\": {\"*\": [\"devs\"], \"webhooks.create-subscription\": [\"users/joe.bloggs\"]}}")
+        okJson("{\"actions\": {\"*\": {\"permissions\": [\"devs\"]}, \"webhooks.create-subscription\": {\"permissions\": [\"users/joe.bloggs\"]}}}")
       ))
 
       val actions = test.underTest.getActions
@@ -71,7 +69,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
       val test = TestSuite()
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.configPath}")).willReturn(
-        okJson("{\"actions\": {\"*\": [\"devs\"], \"webhooks.create-subscription\": [\"users/joe.bloggs\"]}}")
+        okJson("{\"actions\": {\"*\": {\"permissions\": [\"devs\"]}, \"webhooks.create-subscription\": {\"permissions\": [\"users/joe.bloggs\"]}}}")
       ))
 
       val actions = test.underTest.getActions
@@ -82,7 +80,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
       actions should contain value Action(Set("users/joe.bloggs"))
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.configPath}")).willReturn(
-        okJson("{\"actions\": {\"*\": [\"devs\"]}}")
+        okJson("{\"actions\": {\"*\": {\"permissions\": [\"devs\"]}}}")
       ))
 
       val actionsAfter = test.underTest.getActions
@@ -99,7 +97,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
       val test = TestSuite()
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.configPath}")).willReturn(
-        okJson("{\"actions\": {\"*\": [\"devs\"], \"webhooks.create-subscription\": [\"users/joe.bloggs\"]}}")
+        okJson("{\"actions\": {\"*\": {\"permissions\": [\"devs\"]}, \"webhooks.create-subscription\": {\"permissions\": [\"users/joe.bloggs\"]}}}")
       ))
 
       val actions = test.underTest.getActions
@@ -112,7 +110,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
       Thread.sleep(1000)
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.configPath}")).willReturn(
-        okJson("{\"actions\": {\"*\": [\"devs\"]}}")
+        okJson("{\"actions\": {\"*\": {\"permissions\": [\"devs\"]}}}")
       ))
 
       val actionsAfter = test.underTest.getActions
@@ -142,7 +140,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.identitiesPath}")).willReturn(
         okJson(
-          "[{\"LockIndex\":0,\"Key\":\"rbac/identities/users/joe.bloggs\",\"Flags\":0,\"Value\":\"WwogICJkZXZzIgpd\",\"CreateIndex\":142363424,\"ModifyIndex\":142363424}]"
+          "[{\"LockIndex\":0,\"Key\":\"rbac/identities/users/joe.bloggs\",\"Flags\":0,\"Value\":\"eyAiZ3JvdXBzIjogWyJkZXZzIl0gfQ\",\"CreateIndex\":142363424,\"ModifyIndex\":142363424}]"
         )
       ))
 
@@ -157,7 +155,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.identitiesPath}")).willReturn(
         okJson(
-          "[{\"LockIndex\":0,\"Key\":\"rbac/identities/users/joe.bloggs\",\"Flags\":0,\"Value\":\"WwogICJkZXZzIgpd\",\"CreateIndex\":142363424,\"ModifyIndex\":142363424}]"
+          "[{\"LockIndex\":0,\"Key\":\"rbac/identities/users/joe.bloggs\",\"Flags\":0,\"Value\":\"eyAiZ3JvdXBzIjogWyJkZXZzIl0gfQ\",\"CreateIndex\":142363424,\"ModifyIndex\":142363424}]"
         )
       ))
 
@@ -185,7 +183,7 @@ class ConsulAuthConfigProviderTest extends AsyncWordSpec with Matchers with Befo
 
       stubFor(get(urlPathEqualTo(s"/${test.underTest.identitiesPath}")).willReturn(
         okJson(
-          "[{\"LockIndex\":0,\"Key\":\"rbac/identities/users/joe.bloggs\",\"Flags\":0,\"Value\":\"WwogICJkZXZzIgpd\",\"CreateIndex\":142363424,\"ModifyIndex\":142363424}]"
+          "[{\"LockIndex\":0,\"Key\":\"rbac/identities/users/joe.bloggs\",\"Flags\":0,\"Value\":\"eyAiZ3JvdXBzIjogWyJkZXZzIl0gfQ\",\"CreateIndex\":142363424,\"ModifyIndex\":142363424}]"
         )
       ))
 


### PR DESCRIPTION
Also remove reliance on parent object mapper, always pass in the cmd serialised